### PR TITLE
Minor updates and error Fixes

### DIFF
--- a/specifications/cdsc-wg2-03.md
+++ b/specifications/cdsc-wg2-03.md
@@ -1,4 +1,4 @@
-# _CDSC-WG2-03 - Endpoints_ 
+># _CDSC-WG2-03 - Endpoints_ 
 
 Version: _0.0.1_
 Status: Pre-Draft
@@ -200,13 +200,13 @@ Content-Type: application/json;charset=UTF-8
    "types": [
 	   {
 		   "name": "Solar - Photovoltaic - Unspecified",
-		   "external_reference": "EECS Rules Fact Sheet 5 TYPES OF ENERGY INPUTS AND TECHNOLOGIES",
-		   "external_id": "T010100"
+		   "sourceDocument": "EECS Rules Fact Sheet 5 TYPES OF ENERGY INPUTS AND TECHNOLOGIES",
+		   "aibCode": "T010100"
 	   },
 	   {
 		   "name": "Fossil - Solid - Hard Coal - Unspecified",
 		   "external_reference": "EECS Rules Fact Sheet 5 TYPES OF ENERGY INPUTS AND TECHNOLOGIES",
-		   "external_id": "F02010100"
+		   "aibCode": "F02010100"
 	   },
   ],
   "next": null,

--- a/specifications/cdsc-wg2-03.md
+++ b/specifications/cdsc-wg2-03.md
@@ -1,4 +1,4 @@
-># _CDSC-WG2-03 - Endpoints_ 
+# _CDSC-WG2-03 - Endpoints_ 
 
 Version: _0.0.1_
 Status: Pre-Draft

--- a/specifications/cdsc-wg2-03.md
+++ b/specifications/cdsc-wg2-03.md
@@ -199,15 +199,16 @@ Content-Type: application/json;charset=UTF-8
 {
    "types": [
 	   {
-		   "name": "Solar - Photovoltaic - Unspecified",
-		   "sourceDocument": "EECS Rules Fact Sheet 5 TYPES OF ENERGY INPUTS AND TECHNOLOGIES",
-		   "aibCode": "T010100"
-	   },
-	   {
 		   "name": "Fossil - Solid - Hard Coal - Unspecified",
 		   "external_reference": "EECS Rules Fact Sheet 5 TYPES OF ENERGY INPUTS AND TECHNOLOGIES",
 		   "aibCode": "F02010100"
 	   },
+     {
+		   "name": "Mechanical source or other - Wind - Unspecified",
+		   "sourceDocument": "EECS Rules Fact Sheet 5 TYPES OF ENERGY INPUTS AND TECHNOLOGIES",
+			 "aibCode": "F01050100"
+		},
+	   
   ],
   "next": null,
   "previous": null
@@ -243,19 +244,20 @@ Content-Type: application/json;charset=UTF-8
 {
    "technologies": [
 	   {
-		   "name": "Mechanical source or other - Wind - Unspecified",
-		   "externalReference": {
-			   "sourceDocument": "EECS Rules Fact Sheet 5 TYPES OF ENERGY INPUTS AND TECHNOLOGIES",
-			   "aibCode": "F01050100"
-		   }
-	   },
-	   {
 		   "name": "Thermal - Steam engine - Unspecified",
 		   "externalReference": {
 			   "sourceDocument": "EECS Rules Fact Sheet 5 TYPES OF ENERGY INPUTS AND TECHNOLOGIES",
 			   "aibCode": "T050900"
 			 }
 	   },
+
+     {
+		   "name": "Solar - Photovoltaic - Unspecified",
+       "externalReference": {
+		      "sourceDocument": "EECS Rules Fact Sheet 5 TYPES OF ENERGY INPUTS AND TECHNOLOGIES",
+		      "aibCode": "T010100"
+       }
+     },
   ],
   "next": null,
   "previous": null

--- a/specifications/cdsc-wg2-03.md
+++ b/specifications/cdsc-wg2-03.md
@@ -42,8 +42,8 @@ The following is a list of the endpoints that will be subsequently defined in th
 /metadata/topology-levels (LIST)
 /metadata/fuel-source/types (LIST)
 /metadata/fuel-source/technologies (LIST)
-/power-system-resources (LIST) 
 # PSR-Specific Metadata
+/power-system-resources (LIST) 
 /power-system-resources/{id}/describe (GET)
 /power-system-resources/{id}/capacity (GET)
 /power-system-resources/{id}/transmission-capacity (GET)
@@ -268,7 +268,57 @@ Content-Type: application/json;charset=UTF-8
 
 The primary set of endpoints reference PowerSystemResource (PSR) objects. These objects contain several metadata fields about these PSRs.
 
-#### 3.2.1 PSR Topology (List) `/power-system-resources/{id}/topology`
+#### 3.2.1 PSR (List) `/power-system-resources`
+
+##### Description
+The primary set of endpoints reference PowerSystemResource (PSR) objects. These objects contain several metadata fields as well as **historical timeseries** information such as capacity.
+
+##### Request Object
+- `level`: _Integer_ - (OPTIONAL) - An optional filter to only return PSR objects with the given *topology level*.
+
+##### Response Object
+- `id` - _string_ - (REQUIRED) - The unique identifier representing this resource. It SHOULD be human-readable, and where appropriate, MAY incorporate the `id` of its parent objects in order to easily understand its place in the topology. An example of such an id is `US-WECC-CISO`. The `id` MUST be URL safe. 
+- `level` - _string_ - (REQUIRED) - The id of the topology level for this PSR.
+-  `name` - _string_ - (OPTIONAL) - A descriptive name to provide additional context to the PSR.
+
+#### Example
+The following is an example of the endpoint that returns a list of power system resources. This LIST endpoint SHOULD only includes the `id`, `name`, and `type` fields. It MUST not contain fields of undefined size (such as fields that con contain lists or dicts), as this endpoint is meant to be capable of returning several entries.
+
+```
+==Request==
+GET /power-system-resources HTTP/1.1
+Host: demoutility.com
+
+==Response==
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+```
+
+```json
+{
+  "power_system_resources": [
+    {
+      "id": "US-WECC",
+      "name": "Western Electricity Coordinating Council",
+      "level": 0
+    },
+    {
+      "id": "US-WECC-CISO",
+      "name": "California ISO",
+      "level": 1
+    },
+    {
+      "id": "US-WECC-CISO-ABC-HYDRO",
+      "name": "Hydropower Plant in ABC",
+      "level": 2
+    }
+  ],
+  "next": null,
+  "previous": null
+}
+```
+
+#### 3.2.2 PSR Topology (List) `/power-system-resources/{id}/topology`
 
 ##### Description
 
@@ -328,55 +378,6 @@ Content-Type: application/json;charset=UTF-8
 }` 
 ```
 
-#### 3.2.2 PSR (List) `/power-system-resources`
-
-##### Description
-The primary set of endpoints reference PowerSystemResource (PSR) objects. These objects contain several metadata fields as well as **historical timeseries** information such as capacity.
-
-##### Request Object
-- `level`: _Integer_ - (OPTIONAL) - An optional filter to only return PSR objects with the given *topology level*.
-
-##### Response Object
-- `id` - _string_ - (REQUIRED) - The unique identifier representing this resource. It SHOULD be human-readable, and where appropriate, MAY incorporate the `id` of its parent objects in order to easily understand its place in the topology. An example of such an id is `US-WECC-CISO`. The `id` MUST be URL safe. 
-- `level` - _string_ - (REQUIRED) - The id of the topology level for this PSR.
--  `name` - _string_ - (OPTIONAL) - A descriptive name to provide additional context to the PSR.
-
-#### Example
-The following is an example of the endpoint that returns a list of power system resources. This LIST endpoint SHOULD only includes the `id`, `name`, and `type` fields. It MUST not contain fields of undefined size (such as fields that con contain lists or dicts), as this endpoint is meant to be capable of returning several entries.
-
-```
-==Request==
-GET /power-system-resources HTTP/1.1
-Host: demoutility.com
-
-==Response==
-HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
-```
-
-```json
-{
-  "power_system_resources": [
-    {
-      "id": "US-WECC",
-      "name": "Western Electricity Coordinating Council",
-      "level": 0
-    },
-    {
-      "id": "US-WECC-CISO",
-      "name": "California ISO",
-      "level": 1
-    },
-    {
-      "id": "US-WECC-CISO-ABC-HYDRO",
-      "name": "Hydropower Plant in ABC",
-      "level": 2
-    }
-  ],
-  "next": null,
-  "previous": null
-}
-```
 
 #### 3.2.3 PSR Describe `/power-system-resources/{id}/describe`
 


### PR DESCRIPTION
This PR aims to fix some minor errors in the Power System Data Specifications:

This PR aims to solve the problems described at #95 

## Inconsistent naming for FuelSources references:

Unifies naming to `sourceDocument` and `aibCode`

## Wrong assignment of fuel types and references

Fix examples but assigning them to the proper category

## PSR List missing wrong location and indexing

Locate PSR list as the first element under PSR metadata


